### PR TITLE
Bands on Twitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,25 @@ Then pipe the playlist to `cpe play -o mix.wav`. You will get all the tracks
 mixed into a single audio file named `mix.wav`. On stdout you will get the
 playlist with extra `start-time` fields, which can be piped to `cpe export` to
 create a CUE sheet for the mix.
+
+## Follow your favourite bands on Twitter
+
+You can use Calliope to find the Twitter handles of a list of artists.
+
+First you need to get hold of a list of your favourite artists. One way is to
+take the output of `cpe tracker`. You can strip the list down to just artists
+using `yq '{ collection : [ { 'artist': .[][].artist } ] }'`.
+
+Now pipe that list to `cpe musicbrainz --include urls` and you'll get a list
+of relationship URLs for each artist.
+
+Finally, pipe that into `jq`:
+
+    jq '. | ."musicbrainz.artist.urls" // [] | .[]."musicbrainz.url.target" | "@" + match("^http[s]?://(www\\\.)?twitter.com/(.*)").captures[1].string' -r |sort -u
+
+Now you have a list of Twitter handles. Using a tool such as
+[t (Twitter CLI)](https://github.com/sferik/t) you can add all these handles to
+a list, or you can just follow all of them directly. Note that you have to fill
+in a bunch of forms in order to get a Twitter API key before you can use a
+Twitter CLI tool. The `t authorize` command will point you in the right
+direction.


### PR DESCRIPTION
This branch extends `cpe musicbrainz` with a `--include urls` option which will annotate playlists with all the associated URLs for the given artist.

It also adds caching of results to `cpe musicbrainz`.

It switches `cpe musicbrainz` to a new jq-compatible output format that I have been considering in https://github.com/ssssam/calliope/issues/6. This is inconsistent with the rest of the tooling, so that issue needs to be resolved one way or the other before merging this.