### PR TITLE
Change how optional modules are imported

### DIFF
--- a/calliope/meson.build
+++ b/calliope/meson.build
@@ -1,4 +1,5 @@
 sources = [
+  '__init__.py',
   '__main__.py',
   'cache.py',
   'config.py',
@@ -64,8 +65,8 @@ install_data(
     install_dir: join_paths(python_site_packages_dir, 'calliope'))
 
 configure_file(
-    input: '__init__.py.in',
-    output: '__init__.py',
+    input: 'modules.json.in',
+    output: 'modules.json',
     configuration: cdata,
     install_dir: join_paths(python_site_packages_dir, 'calliope'))
 

--- a/meson.build
+++ b/meson.build
@@ -87,12 +87,14 @@ pytest_workdir = meson.current_source_dir()
 
 cdata = configuration_data()
 cdata.set('pythondir', python_site_packages_dir)
-cdata.set('enable_lastfm', get_option('lastfm'))
-cdata.set('enable_musicbrainz', get_option('musicbrainz'))
-cdata.set('enable_play', get_option('play'))
-cdata.set('enable_spotify', get_option('spotify'))
-cdata.set('enable_suggest', get_option('suggest'))
-cdata.set('enable_tracker', get_option('tracker'))
+cdata.set10('enable_lastfm', get_option('lastfm'))
+cdata.set10('enable_musicbrainz', get_option('musicbrainz'))
+cdata.set10('enable_play', get_option('play'))
+cdata.set10('enable_spotify', get_option('spotify'))
+cdata.set10('enable_suggest', get_option('suggest'))
+cdata.set10('enable_tracker', get_option('tracker'))
+
+top_build_dir = meson.current_build_dir()
 
 subdir('calliope')
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -7,6 +7,7 @@ tests = [
 ]
 
 pytest_env = environment()
+pytest_env.set('CALLIOPE_MODULES_CONFIG', join_paths(top_build_dir, 'calliope', 'modules.json'))
 # FIXME: doing 'prepend' twice seems to lose one of the values; possibly a
 # bug in Meson 0.44.1..
 pytest_env.prepend('PYTHONPATH', '@0@:@1@'.format(


### PR DESCRIPTION
Rather than generating __init__.py from the template, we generate a JSON
file which is loaded by __init__.py at runtime.

This fixes the test suite, which was completely broken since commit
5e70f8582d252e9dcf36a11ab6d43325af799dba.

Fixes #19 