### PR TITLE
Use Pylint to catch some mistakes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,12 @@ jobs:
             ninja
 
       - run:
+          name: run pylint
+          command: |
+            cd build
+            ninja pylint
+
+      - run:
           name: run tests
           command: |
             cd build

--- a/calliope/lastfm/__init__.py
+++ b/calliope/lastfm/__init__.py
@@ -153,7 +153,8 @@ def add_lastfm_artist_top_tags(lastfm, cache, item):
     if found:
         log.debug("Found artist-top-tags:{} in cache".format(artist_name))
     else:
-        log.debug("Didn't find artist-top-tags:{} in cache, running remote query".format(artist_name))
+        log.debug("Didn't find artist-top-tags:{} in cache, running "
+                  "remote query".format(artist_name))
 
         try:
             entry = lastfm.artist.get_top_tags(artist_name)

--- a/calliope/lastfm/__init__.py
+++ b/calliope/lastfm/__init__.py
@@ -126,7 +126,7 @@ def prompt_for_user_token(username, client_id=None, client_secret=None,
         import webbrowser
         webbrowser.open(auth_url)
         print("Opened %s in your browser" % auth_url)
-    except:
+    except webbrowser.Error:
         print("Please navigate here: %s" % auth_url)
 
     print("\n")

--- a/calliope/lastfm/__init__.py
+++ b/calliope/lastfm/__init__.py
@@ -41,6 +41,8 @@ class LastfmContext():
         self.user = user
         log.debug("LastFM user: {}".format(user))
 
+        self.api = None
+
         self.cache = calliope.cache.open(namespace='lastfm')
 
     def authenticate(self):

--- a/calliope/lastfm/history.py
+++ b/calliope/lastfm/history.py
@@ -61,7 +61,6 @@ class Store:
                     raise
                 else:
                     time.sleep(0.1)
-                    pass
 
     def cursor(self):
         return self.db.cursor()

--- a/calliope/lastfm/history.py
+++ b/calliope/lastfm/history.py
@@ -149,8 +149,6 @@ class _LastfmHistory:
     def intern_scrobble(self, play_info):
         datetime, trackname, artistname, albumname, trackmbid, artistmbid, \
             albummbid = play_info
-        uri = 'lastfm://%s/%s/' % (escape_for_lastfm_uri(artistname),
-                                   escape_for_lastfm_uri(trackname))
 
         cursor = self.store.cursor()
         find_lastfm_sql = 'SELECT id FROM imports_lastfm ' \

--- a/calliope/lastfm/history.py
+++ b/calliope/lastfm/history.py
@@ -204,7 +204,7 @@ class _LastfmHistory:
               '                albumname, trackmbid, artistmbid, albummbid ' + \
               '           FROM imports_lastfm ) ' + \
               '  GROUP BY trackid HAVING playcount > ? ' + \
-              '  ORDER BY trackid';
+              '  ORDER BY trackid'
         cursor = self.store.cursor()
         cursor.execute(sql, [min_listens])
         for row in cursor:

--- a/calliope/lastfm/history.py
+++ b/calliope/lastfm/history.py
@@ -112,7 +112,7 @@ class _LastfmHistory:
             'last.fm', self.username, tracktype='recenttracks')
 
         page_size = None
-        timeouts = 0
+        total_pages = 0
         for page, total_pages, tracks in gen:
             if tracks is None:
                 # This can happen when a fetch request times out.

--- a/calliope/lastfm/lastexport.py
+++ b/calliope/lastfm/lastexport.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 #-*- coding: utf-8 -*-
+#pylint: disable=W,C
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/calliope/meson.build
+++ b/calliope/meson.build
@@ -66,6 +66,3 @@ endif
 if get_option('web')
   subdir('data/web/templates')
 endif
-
-#calliope = custom_target('calliope',
-#    depend_files: all_sources)

--- a/calliope/musicbrainz/__init__.py
+++ b/calliope/musicbrainz/__init__.py
@@ -38,10 +38,10 @@ def add_musicbrainz_artist(cache, item):
     else:
         log.debug("Didn't find artist:{} in cache, running remote query".format(artist_name))
         result = musicbrainzngs.search_artists(artist=artist_name)['artist-list']
-        if len(result) == 0:
-            entry = None
-        else:
+        if result:
             entry = result[0]
+        else:
+            entry = None
 
         cache.store('artist:{}'.format(artist_name), entry)
 

--- a/calliope/play/__init__.py
+++ b/calliope/play/__init__.py
@@ -38,7 +38,7 @@ def set_element_state_sync(pipeline, target_state):
     bus = pipeline.get_bus()
     pipeline.set_state(target_state)
     while True:
-        ret, state, pending = pipeline.get_state(1 * 1000 * 1000 * 1000)
+        ret, state, _pending = pipeline.get_state(1 * 1000 * 1000 * 1000)
         if ret == Gst.StateChangeReturn.FAILURE:
             msg = bus.pop_filtered(Gst.MessageType.ERROR)
             if msg:
@@ -134,7 +134,7 @@ def play(tracks, audio_output):
             # We use the sync message handler to get the exact timestamp that
             # each new track begins at.
             if message.type == Gst.MessageType.STREAM_START:
-                result, timestamp = pipeline.query_position(Gst.Format.TIME)
+                _result, timestamp = pipeline.query_position(Gst.Format.TIME)
                 stream_state['track-index'] += 1
                 index = stream_state['track-index']
                 log.debug("New stream started. Now at track %i; timestamp %s", index, timestamp)
@@ -167,4 +167,4 @@ def play(tracks, audio_output):
         log.debug("Complete")
         set_element_state_sync(pipeline, Gst.State.NULL)
 
-    return calliope.Playlist({'list': output_playlist})
+    return output_playlist

--- a/calliope/play/__init__.py
+++ b/calliope/play/__init__.py
@@ -80,7 +80,7 @@ def play(tracks, audio_output):
         output_playlist.append(item)
     file_uris = list(reversed(file_uris))
 
-    if len(file_uris) == 0:
+    if not file_uris:
         return None
 
     pipeline = Gst.Pipeline.new()
@@ -112,7 +112,7 @@ def play(tracks, audio_output):
         def decode_pad_added(element, pad):
             log.debug("Pad added")
             pad.link(concat.get_request_pad('sink_%u'))
-            if len(uri_list) > 0:
+            if uri_list:
                 enqueue_songs(uri_list, i+1)
         uridecodebin.connect('pad-added', decode_pad_added)
 

--- a/calliope/play/__init__.py
+++ b/calliope/play/__init__.py
@@ -152,7 +152,7 @@ def play(tracks, audio_output):
                 if message.type == Gst.MessageType.ERROR:
                     error = message.parse_error()
                     log.debug(error.debug)
-                    raise(error.gerror)
+                    raise error.gerror
                 elif message.type == Gst.MessageType.EOS:
                     index = stream_state['track-index'] + 1
                     update_item_from_timestamp(output_playlist[index], stream_state['time'])

--- a/calliope/play/__init__.py
+++ b/calliope/play/__init__.py
@@ -75,7 +75,7 @@ def play(tracks, audio_output):
     for item in tracks:
         if 'location' not in item:
             raise RuntimeError("All tracks must have the 'location' "
-                                "property set in order to render audio.")
+                               "property set in order to render audio.")
         file_uris.append(item['location'])
         output_playlist.append(item)
     file_uris = list(reversed(file_uris))

--- a/calliope/spotify/__init__.py
+++ b/calliope/spotify/__init__.py
@@ -45,6 +45,8 @@ class SpotifyContext():
         self.user = user
         log.debug("Spotify user: {}".format(user))
 
+        self.api = None
+
     def authenticate(self, token=None):
         if not token:
             client_id = calliope.config.get('spotify', 'client-id')

--- a/calliope/spotify/__init__.py
+++ b/calliope/spotify/__init__.py
@@ -72,7 +72,7 @@ def annotate_track(sp, track_entry):
     log.debug("Searching for track: %s", track_entry)
     result = sp.search(q=track_entry['track'], type='track')
 
-    if len(result['tracks']['items']) > 0:
+    if result['tracks']['items']:
         first_result = result['tracks']['items'][0]
 
         track_entry['spotify.artist'] = flatten([

--- a/calliope/suggest/__init__.py
+++ b/calliope/suggest/__init__.py
@@ -44,9 +44,10 @@ def suggest_tracks(corpus_playlist, count, training_input):
         for item in playlist_stream:
             for track in item.tracks():
                 track_index = corpus_tracks.index(track)
-                if track_id:
-                    interaction_list[track_id] = weight
+                if track_index:
+                    interaction_list[track_index] = weight
         interaction_matrix.append(interaction_list)
 
     interaction_matrix = numpy.matrix(interaction_matrix)
     print(interaction_matrix)
+    print(count)

--- a/calliope/tracker/__init__.py
+++ b/calliope/tracker/__init__.py
@@ -231,7 +231,7 @@ class TrackerClient():
                 'track': songs_with_releases.get_string(2)[0],
                 'location': songs_with_releases.get_string(0)[0]
             })
-        if len(album_tracks) > 0:
+        if album_tracks:
             yield {
                 'artist': current_artist_name,
                 'album': album_name,
@@ -256,7 +256,7 @@ class TrackerClient():
                     'track': songs_without_releases.get_string(2)[0],
                     'location': songs_without_releases.get_string(0)[0]
                 })
-            if len(catchall_tracks) > 0:
+            if catchall_tracks:
                 yield {
                     'artist': current_artist_name,
                     'tracks': catchall_tracks

--- a/calliope/tracker/__init__.py
+++ b/calliope/tracker/__init__.py
@@ -343,11 +343,13 @@ def add_location(tracker, item):
     if tracks:
         for track in tracks:
             result.extend(
-                list(tracker.songs(filter_artist_name=item.get('artist'), filter_track_name=str(track))))
+                list(tracker.songs(filter_artist_name=item.get('artist'),
+                                   filter_track_name=str(track))))
     elif albums:
         for album in albums:
             result.extend(
-                list(tracker.songs(filter_artist_name=item.get('artist'), filter_album_name=str(album))))
+                list(tracker.songs(filter_artist_name=item.get('artist'),
+                                   filter_album_name=str(album))))
     else:
         result = list(tracker.songs(filter_artist_name=item['artist']))
 

--- a/calliope/tracker/__init__.py
+++ b/calliope/tracker/__init__.py
@@ -151,7 +151,6 @@ class TrackerClient():
         else:
             album_pattern = ""
         if filter_track_name:
-            assert track_search_text is None, "Cannot pass both filter_track_name and track_search_text"
             track_pattern = """
                 ?track nie:title ?trackTitle .
                 FILTER (LCASE(?trackTitle) = "%s")
@@ -198,8 +197,6 @@ class TrackerClient():
                 query_songs_without_releases)
         else:
             songs_without_releases = None
-
-        result = []
 
         # The artist name may be returned as None if it's unknown to Tracker,
         # so we can't use None as an 'undefined' value. int(-1) will work,

--- a/calliope/tracker/__init__.py
+++ b/calliope/tracker/__init__.py
@@ -287,7 +287,7 @@ class TrackerContext():
             # directly here... but I'm not sure how else to get Click to run
             # the cleanup function.
             self._mgr = trackerappdomain.tracker_app_domain('uk.me.afuera.calliope', app_domain_dir)
-            tracker_app_domain = self._mgr.__enter__()
+            tracker_app_domain = self._mgr.__enter__()  # pylint: disable=no-member
 
             self.app_domain = tracker_app_domain
             self.sparql_connection = tracker_app_domain.connection()
@@ -302,7 +302,7 @@ class TrackerContext():
 
     def cleanup(self):
         if self._mgr is not None:
-            self._mgr.__exit__(None, None, None)
+            self._mgr.__exit__(None, None, None)    # pylint: disable=no-member
 
 
 def add_location(tracker, item):

--- a/calliope/tracker/__init__.py
+++ b/calliope/tracker/__init__.py
@@ -310,7 +310,7 @@ class TrackerContext():
 
 def add_location(tracker, item):
     if 'artist' not in item and 'album' not in item and 'track' not in item:
-        raise RuntimeError (
+        raise RuntimeError(
             "All items must specify at least 'artist', 'album' or 'track': got %s" %
             item)
 

--- a/calliope/web/__init__.py
+++ b/calliope/web/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Calliope
 # Copyright (C) 2018  Sam Thursfield <sam@afuera.me.uk>
 #

--- a/meson.build
+++ b/meson.build
@@ -88,7 +88,7 @@ if get_option('testsuite')
   endif
 endif
 
-pytest = find_program('pytest-3', required: false)
+pytest = find_program('pytest-3')
 
 ###############################################################################
 # Configuration

--- a/meson.build
+++ b/meson.build
@@ -88,6 +88,8 @@ if get_option('testsuite')
   endif
 endif
 
+pylint = find_program('pylint')
+
 pytest = find_program('pytest-3')
 
 ###############################################################################
@@ -119,6 +121,9 @@ subdir('calliope')
 if get_option('viewer')
   subdir('apps/viewer')
 endif
+
+run_target('pylint',
+  command: [run_from_source_tree, top_source_dir, top_build_dir, pylint.path(), '--rcfile', join_paths(top_source_dir, 'pylintrc')] + calliope_module_sources)
 
 subdir('tests')
 

--- a/pylintrc
+++ b/pylintrc
@@ -152,6 +152,7 @@ disable=print-statement,
         logging-not-lazy,
         fixme,
         no-self-use,
+        bad-whitespace,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/pylintrc
+++ b/pylintrc
@@ -140,6 +140,7 @@ disable=print-statement,
         exception-escape,
         comprehension-escape,
         wrong-import-order,
+        wrong-import-position,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/pylintrc
+++ b/pylintrc
@@ -148,7 +148,8 @@ disable=print-statement,
         too-many-statements,
         no-else-return,
         unused-argument,
-
+        logging-format-interpolation,
+        logging-not-lazy,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/pylintrc
+++ b/pylintrc
@@ -146,6 +146,7 @@ disable=print-statement,
         too-many-branches,
         too-many-locals,
         too-many-statements,
+        no-else-return,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/pylintrc
+++ b/pylintrc
@@ -154,6 +154,7 @@ disable=print-statement,
         no-self-use,
         bad-whitespace,
         duplicate-code,
+        redefined-outer-name,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/pylintrc
+++ b/pylintrc
@@ -206,7 +206,7 @@ argument-naming-style=any
 #argument-rgx=
 
 # Naming style matching correct attribute names.
-attr-naming-style=snake_case
+attr-naming-style=any
 
 # Regular expression matching correct attribute names. Overrides attr-naming-
 # style.

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,566 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        deprecated-operator-function,
+        deprecated-urllib-function,
+        xreadlines-attribute,
+        deprecated-sys-function,
+        exception-escape,
+        comprehension-escape
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[LOGGING]
+
+# Format style used to check logging format string. `old` means using %
+# formatting, while `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: en_MW (myspell), en_GH
+# (myspell), en_SG (myspell), en_NG (myspell), en_HK (myspell), en_IN
+# (myspell), en_ZA (myspell), en_BS (myspell), en_AU (myspell), en_GB
+# (myspell), en_US (myspell), en_AG (myspell), en_TT (myspell), en_PH
+# (myspell), en_NA (myspell), en_JM (myspell), en_IE (myspell), en_BW
+# (myspell), en_NZ (myspell), en_BZ (myspell), en_DK (myspell), en_ZM
+# (myspell), en_ZW (myspell), en_CA (myspell)..
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement.
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception".
+overgeneral-exceptions=Exception

--- a/pylintrc
+++ b/pylintrc
@@ -153,6 +153,7 @@ disable=print-statement,
         fixme,
         no-self-use,
         bad-whitespace,
+        duplicate-code,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/pylintrc
+++ b/pylintrc
@@ -147,6 +147,8 @@ disable=print-statement,
         too-many-locals,
         too-many-statements,
         no-else-return,
+        unused-argument,
+
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/pylintrc
+++ b/pylintrc
@@ -141,6 +141,7 @@ disable=print-statement,
         comprehension-escape,
         wrong-import-order,
         wrong-import-position,
+        missing-docstring,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/pylintrc
+++ b/pylintrc
@@ -150,6 +150,7 @@ disable=print-statement,
         unused-argument,
         logging-format-interpolation,
         logging-not-lazy,
+        fixme,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/pylintrc
+++ b/pylintrc
@@ -195,7 +195,7 @@ never-returning-functions=sys.exit
 [BASIC]
 
 # Naming style matching correct argument names.
-argument-naming-style=snake_case
+argument-naming-style=any
 
 # Regular expression matching correct argument names. Overrides argument-
 # naming-style.

--- a/pylintrc
+++ b/pylintrc
@@ -437,7 +437,7 @@ indent-after-paren=4
 indent-string='    '
 
 # Maximum number of characters on a single line.
-max-line-length=100
+max-line-length=120
 
 # Maximum number of lines in a module.
 max-module-lines=1000

--- a/pylintrc
+++ b/pylintrc
@@ -142,6 +142,10 @@ disable=print-statement,
         wrong-import-order,
         wrong-import-position,
         missing-docstring,
+        too-few-public-methods,
+        too-many-branches,
+        too-many-locals,
+        too-many-statements,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/pylintrc
+++ b/pylintrc
@@ -138,7 +138,8 @@ disable=print-statement,
         xreadlines-attribute,
         deprecated-sys-function,
         exception-escape,
-        comprehension-escape
+        comprehension-escape,
+        wrong-import-order,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -286,7 +287,7 @@ no-docstring-rgx=^_
 property-classes=abc.abstractproperty
 
 # Naming style matching correct variable names.
-variable-naming-style=snake_case
+variable-naming-style=any
 
 # Regular expression matching correct variable names. Overrides variable-
 # naming-style.

--- a/pylintrc
+++ b/pylintrc
@@ -230,11 +230,11 @@ class-naming-style=PascalCase
 #class-rgx=
 
 # Naming style matching correct constant names.
-const-naming-style=UPPER_CASE
+const-naming-style=any
 
 # Regular expression matching correct constant names. Overrides const-naming-
 # style.
-#const-rgx=
+const-rgx=(log|[A-Z_]+)
 
 # Minimum line length for functions/classes that require docstrings, shorter
 # ones are exempt.

--- a/pylintrc
+++ b/pylintrc
@@ -151,6 +151,7 @@ disable=print-statement,
         logging-format-interpolation,
         logging-not-lazy,
         fixme,
+        no-self-use,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,7 +41,7 @@ def test_shuffle(cli):
 
 def test_spotify(cli):
     os.environ['CALLIOPE_SPOTIFY_MOCK'] = 'yes'
-    result = cli.run(['--debug' ,'spotify'])
+    result = cli.run(['--debug', 'spotify'])
     assert result.exit_code == 0
     result = cli.run(['--debug', 'spotify', '--user', '__calliope_tests', 'annotate', '-'], input='')
     assert result.exit_code == 0

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -25,13 +25,13 @@ def test_export_cue(cli):
     ]
 
     expected_output = '\n'.join([
-      "FILE \"none\" WAVE",
-      "  TRACK 01 AUDIO",
-      "    PERFORMER \"Test1\"",
-      "  INDEX 01 00:00:00",
-      "  TRACK 02 AUDIO",
-      "    PERFORMER \"Test2\"",
-      "  INDEX 01 00:50:00"])
+        "FILE \"none\" WAVE",
+        "  TRACK 01 AUDIO",
+        "    PERFORMER \"Test1\"",
+        "  INDEX 01 00:00:00",
+        "  TRACK 02 AUDIO",
+        "    PERFORMER \"Test2\"",
+        "  INDEX 01 00:50:00"])
 
     result = cli.run(['export', '--format=cue', '-'], input='\n'.join(json.dumps(track) for track in input_tracks))
 


### PR DESCRIPTION
This adds a `ninja pylint` target that can be run by developers, and fixes lots of warnings that were showing up (and disables lots more).

Currently pylint is a hard dependency of calliope. In future it can be made optional, although a specific hard-disable flag would be best.