### PR TITLE
lastfm-history: Allow filtering tracks by first play / last play date

### DIFF
--- a/calliope/cli.py
+++ b/calliope/cli.py
@@ -21,6 +21,7 @@ This module provides the public command line interface for Calliope.
 '''
 
 import click
+import dateparser
 import xdg.BaseDirectory
 
 import logging
@@ -186,12 +187,36 @@ def cmd_lastfm_history_scrobbles(context):
 
 @lastfm_history_cli.command(name='tracks',
                             help="Query tracks from the listening history")
+@click.option('--first-play-before', metavar='DATE',
+              help="show tracks that were first played before DATE")
+@click.option('--first-play-since', metavar='DATE',
+              help="show tracks that were first played on or after DATE")
+@click.option('--last-play-before', metavar='DATE',
+              help="show tracks that were last played before DATE")
+@click.option('--last-play-since', metavar='DATE',
+              help="show tracks that were last played on or after DATE")
 @click.option('--min-listens', default=1, metavar='N',
               help="show only tracks that were played N times")
 @click.pass_context
-def cmd_lastfm_history_tracks(context, min_listens):
+def cmd_lastfm_history_tracks(context, first_play_before, first_play_since,
+                              last_play_before, last_play_since, min_listens):
     lastfm_history = context.obj.lastfm_history
-    tracks = lastfm_history.tracks(min_listens=min_listens)
+
+    if first_play_before is not None:
+        first_play_before = dateparser.parse(first_play_before)
+    if first_play_since is not None:
+        first_play_since = dateparser.parse(first_play_since)
+    if last_play_before is not None:
+        last_play_before = dateparser.parse(last_play_before)
+    if last_play_since is not None:
+        last_play_since = dateparser.parse(last_play_since)
+
+    tracks = lastfm_history.tracks(
+        first_play_before=first_play_before,
+        first_play_since=first_play_since,
+        last_play_before=last_play_before,
+        last_play_since=last_play_since,
+        min_listens=min_listens)
     calliope.playlist.write(tracks, sys.stdout)
 
 

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -7,6 +7,7 @@ sphinx_sources = [
   'use-cases/copy-onto-portable-device.rst',
   'use-cases/create-mix.rst',
   'use-cases/follow-top-artists-on-twitter.rst',
+  'use-cases/listen-history.rst',
   'use-cases/never-listened.rst',
   'use-cases/selecting-from-a-collection.rst',
   'use-cases/top-artists.rst',

--- a/docs/use-cases.rst
+++ b/docs/use-cases.rst
@@ -7,6 +7,7 @@ Use cases
    use-cases/copy-onto-portable-device
    use-cases/create-mix
    use-cases/follow-top-artists-on-twitter
+   use-cases/listen-history
    use-cases/never-listened
    use-cases/selecting-from-a-collection
    use-cases/top-artists

--- a/docs/use-cases/listen-history.rst
+++ b/docs/use-cases/listen-history.rst
@@ -1,0 +1,31 @@
+.. _listen_history:
+
+Analysing someone's listen history
+==================================
+
+The ``cpe lastfm-history`` command can provide a record of songs that you have
+listened to. It has some tools to help analyse this data as well.
+
+Music which you haven't listened to for over a year
+---------------------------------------------------
+
+Start with this command:
+
+.. code:: bash
+
+   cpe lastfm-history tracks --last-play-before='1 year ago'
+
+This gives you a raw list of tracks.
+
+Perhaps some of these tracks haven't been played in a long time because you
+don't like them.
+
+You might add ``--min-listens=5`` to remove tracks that you
+didn't play many times to reduce the size of the list.
+
+You can select tracks from your local collection that you didn't listen to
+in over a year using this command:
+
+.. code:: bash
+
+   cpe lastfm-history tracks --last-play-before='1 year ago' --min-listens=5 | cpe tracker annotate - | jq 'select(.["tracker.url"])'

--- a/meson.build
+++ b/meson.build
@@ -28,6 +28,7 @@ endif
 
 install_requires = [
   'click',
+  'dateparser',
   'pyxdg',
 ]
 

--- a/pylintrc
+++ b/pylintrc
@@ -156,6 +156,7 @@ disable=print-statement,
         duplicate-code,
         redefined-outer-name,
         bad-continuation,
+        too-many-arguments,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option


### PR DESCRIPTION
This adds `lastfm.first_play` and `lastfm.last_play` attributes into the
generated playlist, and adds --first-play-before, --first-play-since,
--last-play-before and --last-play-since options to allow more
filtering.

There's a new "Music which you haven't listened to in a while" use case
added to the documentation.