### PR TITLE
Replace 'dateparser' with 'parsedatetime'

### DIFF
--- a/calliope/cli.py
+++ b/calliope/cli.py
@@ -21,7 +21,7 @@ This module provides the public command line interface for Calliope.
 '''
 
 import click
-import dateparser
+import parsedatetime
 import xdg.BaseDirectory
 
 import logging
@@ -202,14 +202,16 @@ def cmd_lastfm_history_artists(context, first_play_before, first_play_since,
                                last_play_before, last_play_since, min_listens):
     lastfm_history = context.obj.lastfm_history
 
+    cal = parsedatetime.Calendar()
+
     if first_play_before is not None:
-        first_play_before = dateparser.parse(first_play_before)
+        first_play_before = cal.parse(first_play_before)
     if first_play_since is not None:
-        first_play_since = dateparser.parse(first_play_since)
+        first_play_since = cal.parse(first_play_since)
     if last_play_before is not None:
-        last_play_before = dateparser.parse(last_play_before)
+        last_play_before = cal.parse(last_play_before)
     if last_play_since is not None:
-        last_play_since = dateparser.parse(last_play_since)
+        last_play_since = cal.parse(last_play_since)
 
     artists = lastfm_history.artists(
         first_play_before=first_play_before,
@@ -236,14 +238,16 @@ def cmd_lastfm_history_tracks(context, first_play_before, first_play_since,
                               last_play_before, last_play_since, min_listens):
     lastfm_history = context.obj.lastfm_history
 
+    cal = parsedatetime.Calendar()
+
     if first_play_before is not None:
-        first_play_before = dateparser.parse(first_play_before)
+        first_play_before = cal.parse(first_play_before)
     if first_play_since is not None:
-        first_play_since = dateparser.parse(first_play_since)
+        first_play_since = cal.parse(first_play_since)
     if last_play_before is not None:
-        last_play_before = dateparser.parse(last_play_before)
+        last_play_before = cal.parse(last_play_before)
     if last_play_since is not None:
-        last_play_since = dateparser.parse(last_play_since)
+        last_play_since = cal.parse(last_play_since)
 
     tracks = lastfm_history.tracks(
         first_play_before=first_play_before,

--- a/meson.build
+++ b/meson.build
@@ -28,7 +28,7 @@ endif
 
 install_requires = [
   'click',
-  'dateparser',
+  'parsedatetime',
   'pyxdg',
 ]
 


### PR DESCRIPTION
The latter appears to have much poorer internationalization, so we might
switch back in future. However we are a long way off from having the
tools accept their commandline arguments in languages other than English
at the moment. Meanwhile, 'dateparser' has some requirements that are
difficult to satisfy on container OSes: the 'regex' module isn't
packaged in Alpine Linux and has C code bundled with it, so `pip
install` needs a full C toolchain available to be able to install this
module. Right now it's not worth that pain.