### PR TITLE
spotify: Fix hidden dependency on 'mock' module

### DIFF
--- a/calliope/cli.py
+++ b/calliope/cli.py
@@ -25,7 +25,6 @@ import parsedatetime
 import xdg.BaseDirectory
 
 import logging
-import mock
 import os
 import sys
 
@@ -307,7 +306,8 @@ def spotify_cli(context, token, user):
         # This is for testing; as we currently run Calliope as a subprocess
         # from the test suite (due to trackerappdomain bugs when run multiple
         # times in the same process) we can't use mock.patch().
-        context.obj.spotify = mock.MagicMock()
+        import unittest.mock
+        context.obj.spotify = unittest.mock.MagicMock()
     else:
         context.obj.spotify = calliope.spotify.SpotifyContext(user=user)
         context.obj.spotify.authenticate(token)


### PR DESCRIPTION
My intention was to use the standard unittest.mock library. And anyway,
we should only be importing this as part of the test suite.