### PR TITLE
Install packaging metadata

### DIFF
--- a/data/calliope.egg-info.in
+++ b/data/calliope.egg-info.in
@@ -1,0 +1,5 @@
+Metadata-Version: 1.2
+Name: calliope
+Version: @version@
+Summary: Playlist toolkit
+License: GPLv2+

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,0 +1,13 @@
+# Generate metadata for Python 'setuptools' packaging. This makes
+# `pkg_resources.require('calliope')` work as expected.
+#
+# See:
+#   <https://setuptools.readthedocs.io/en/latest/formats.html>
+#   <https://packaging.python.org/specifications/core-metadata/>
+#
+configure_file(
+  input: 'calliope.egg-info.in',
+  output: 'calliope-@0@-py@1@.egg-info'.format(meson.project_version(), python.language_version()),
+  configuration: cdata,
+  install: true,
+  install_dir: python.get_install_dir(pure: false))

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,6 @@
 project('calliope',
-        meson_version: '>= 0.47')
+        version: '1',
+        meson_version: '>= 0.50')
 
 # Process the feature dependecies.
 #
@@ -132,6 +133,7 @@ cdata.set10('enable_web', enable_web)
 cdata.set('localedir', localedir)
 cdata.set('pkgdatadir', pkgdatadir)
 cdata.set('pythonsitepackagesdir', python.get_install_dir(pure: false))
+cdata.set('version', meson.project_version())
 
 top_source_dir = meson.current_source_dir()
 top_build_dir = meson.current_build_dir()
@@ -139,6 +141,7 @@ top_build_dir = meson.current_build_dir()
 run_from_source_tree = find_program('scripts/run_from_source_tree', required: true)
 
 subdir('calliope')
+subdir('data')
 
 if enable_viewer_app
   subdir('apps/viewer')


### PR DESCRIPTION
This allows other projects to declare a dependency on Calliope
using the setuptools package management system. It's still only
possible to install Calliope using the Meson build system.

I also set the version number to 1, where it was previously
undefined. This doesn't imply any particular guarantee of API
stability. I was tempted to go straight to 1000, after all
this project has been going for almost 15 years already, but
let's start back at 1.